### PR TITLE
Add WebSocket Stream of Valid Orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /node_modules
+/dist/*.js

--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -1,0 +1,48 @@
+# OrderStream WebSocket API
+One of the most fundemental pieces of the OrderStream network is the event-based orderbook. The primary way to subscribe to this event stream is via a node's WebSocket endpoint:
+```
+ws://localhost:8080/
+```
+If you are running a node, you can listen to the WS stream on localhost. Otherwise you must use a node that has expose it's WebSocket endpoint to the public. For example, the public Paradigm endpoint:
+```
+ws://osd.paradigm.market/api/stream
+```
+## Stream Format
+
+The first message upon connecting to the endpoint is a string with a message, but all others strings that are sent like:
+```js
+ws.send(JSON.stringify(order.toJSON()))
+```
+Raw messages will be strings, but calling `JSON.parse(msg)` will return objects like this:
+
+```json
+{
+    "event": "new-order",
+    "timestamp": 1537905576,
+    "data": {
+        "subContract": "0x...",
+        "maker": "0x...",
+
+        // ... the rest of the Order
+    }    
+}
+```
+You can recover the order object client-side (node.js shown, can be adapted to browser):
+```js
+let paradigm = new Paradigm();
+
+ws.on("message", (msg) => { // msg is the string of above
+    let eventObject = JSON.parse(msg);
+    
+    // ... do external stuff with the order data ...
+    // You can also contstruct Paradigm Order objects:
+    
+    let orderObject = eventObject.data;
+    let order = new paradigm.Order(orderObject)
+
+    console.log(JSON.stringify(order)); // view the order
+
+    // ... and then participate in trades via the OrderGateway:
+
+    order.take(taker, takerArguments);
+});

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -7,7 +7,7 @@
   @date_modified 25 September 2018
   @author Henry Harder
 
-  Logger class to handle logs to STDOUT.
+  Simple Logger class to handle logs to STDOUT.
 */
 
 import { VERSION } from "./config";

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,0 +1,22 @@
+/*
+  =========================
+  Blind Star - codename (developent)
+  Logger.ts @ {master}
+  =========================
+  @date_inital 25 September 2018
+  @date_modified 25 September 2018
+  @author Henry Harder
+
+  Logger class to handle logs to STDOUT.
+*/
+
+import { VERSION } from "./config";
+
+export class Logger {
+    public static logEvent(message): void{
+        console.log(`[ParadigmCore @ v${VERSION}: ${new Date().toLocaleString()}] Event: ${message}`)
+    }
+    public static logError(message): void{
+        console.log(`[ParadigmCore @ v${VERSION}: ${new Date().toLocaleString()}] Error: ${message}`)
+    }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,15 +9,16 @@
 
   Constants and configuration.
 */
-
 export const VERSION: string = "0.0.1a7"; // PC Version 
 
-// public/private ports for ABCI and RPC server
+// endpoints for ABCI/RPC
+export const ABCI_HOST: string = "localhost";
+export const ABCI_RPC_PORT: number = 26657;
+
+// public/private ports for ABCI, RPC, and WS servers
 export const ABCI_PORT: number = 26658;
 export const API_PORT: number = 3000;
-
-// endpoints for ABCI/RPC
-export const ABCI_URI: string = "http://localhost:26657"
+export const WS_PORT: number = 8080;
 
 // encoding types for order transport 
 export const IN_ENC: string = 'utf8'

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,3 +1,4 @@
+
 /*
   =========================
   Blind Star - codename (developent)
@@ -10,5 +11,93 @@
   General functions and utilities, as well as ABCI handlers.
 */
 
-// needed?
+let _pjs = require("paradigm.js");
+let _enc = require("./PayloadCipher").PayloadCipher
+let log = require("./Logger").Logger
+
+let version = require('./config').VERSION;
+let Vote = require('./Vote').Vote;
+
+
+let paradigm = new _pjs(); // new paradigm instance
+let Order = paradigm.Order; 
+
+let cipher = new _enc({ // new Payload
+  inputEncoding: 'utf8',
+  outputEncoding: 'base64'
+});
+
+let state = { // eventually will represent address => limit
+  number: 0
+}
+
+export let handlers = {
+  info: (_) => {
+    return {
+      data: 'Stake Verification App',
+      version: version,
+      lastBlockHeight: 0,
+      lastBlockAppHash: Buffer.alloc(0)
+    }
+  },
+
+  checkTx: (request) => {
+    let txObject;
+    
+    try {
+      txObject = cipher.ABCIdecode(request.tx);
+    } catch (error) {
+      log.logEvent("Bad order post, error decompressing TX - rejected");
+      return Vote.invalid("Bad order, error decompressing TX");
+    }
+
+    try {      
+      let newOrder = new Order(txObject);
+      let recoveredAddr = newOrder.recoverPoster();
+      if (typeof(recoveredAddr) === "string"){ 
+        /*
+          The above conditional shoud rely on a verifyStake(), that checks
+          the existing state for that address. 
+        */        
+        return Vote.valid(`Stake verified, order kept.`);
+      } else {
+        log.logEvent("Bad order post, no stake - rejected")
+        return Vote.invalid('Bad order maker - no stake.');
+      }
+    } catch (error) {
+      log.logEvent("Bad order post, bad format - rejected");
+      return Vote.invalid('Bad order format.');
+    }
+  },
+
+  deliverTx: (request) => {
+    let txObject;
+    
+    try {
+      txObject = cipher.ABCIdecode(request.tx);
+    } catch (error) {
+      log.logEvent("Bad order, error decompressing - rejected")
+      return Vote.invalid('Bad order - error decompressing TX.');
+    }
+
+    try {      
+      let newOrder = new Order(txObject);
+      let recoveredAddr = newOrder.recoverPoster();
+      if (typeof(recoveredAddr) === "string"){ 
+        /*
+          The above conditional shoud rely on a verifyStake(), that checks
+          the existing state for that address. 
+       */
+        log.logEvent("Valid order received (in deliverTx)")
+        return Vote.valid(`Success: stake of '${recoveredAddr}' verified.`);
+      } else {
+        log.logEvent("Bad order post, no stake - rejected")
+        return Vote.invalid('Bad order maker - no stake.');
+      }
+    } catch (error) {
+      log.logEvent("Bad order post, bad format - rejected");
+      return Vote.invalid('Bad order format.');
+    }
+  }
+}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ let paradigm = new _pjs(); // new paradigm instance
 let Order = paradigm.Order;
 
 wss.on("connection", (ws) => {
-  ws.send("hello");
+  ws.send('Connected to the OrderStream network.');
   emitter.on("validOrder", (order) => {
     ws.send(JSON.stringify({
       "event": "new-order",

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,8 +16,9 @@ import * as bodyParser from "body-parser";
 import * as cors from "cors";
 import { PayloadCipher } from "./PayloadCipher"; 
 import { Message } from "./Message";
+import { Logger } from "./Logger";
 
-import { API_PORT, VERSION, ABCI_URI} from "./config";
+import { API_PORT, VERSION, ABCI_HOST, ABCI_RPC_PORT} from "./config";
 
 let pe = new PayloadCipher({
     inputEncoding: 'utf8',
@@ -45,8 +46,8 @@ app.post("/post", (req, res) => {
 
     // deliver TX to ABCI server here
     let options = {
-        hostname: 'localhost',
-        port: 26657,
+        hostname: ABCI_HOST,
+        port: ABCI_RPC_PORT,
         path: getURL
     }
 
@@ -68,6 +69,6 @@ app.post("/post", (req, res) => {
 // to run in-process version, should we have `export function start(){app.listen(...)}` ???
 export function startAPIserver(): void {
     app.listen(API_PORT, () => {
-        console.log(`[PC - API Server @${VERSION}: ${new Date().toLocaleString()}] API server started on port ${API_PORT}.`);
+        Logger.logEvent(`API server started on port ${API_PORT}.`);
     });
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,15 @@
+/*
+  =========================
+  Blind Star - codename (developent)
+  state.ts @ {master}
+  =========================
+  @date_inital 25 September 2018
+  @date_modified 25 September 2018
+  @author Henry Harder
+
+  Object that represents the state of the OS node.
+*/
+
+export let state = {
+  number: 0
+}

--- a/test/ws_test.js
+++ b/test/ws_test.js
@@ -1,0 +1,19 @@
+let WebSocket = require('ws');
+let EventEmitter = require('events').EventEmitter;
+
+let wss = new WebSocket.Server({ port:8080 });
+let em = new EventEmitter()
+
+wss.on('connection', (ws) => {
+    em.on('validOrder', (order) => {
+        console.log()
+        ws.send(JSON.stringify(order));
+        console.log('sent');
+    });
+});
+
+function emitEvent(testOrder){
+    em.emit('validOrder', {"data":testOrder});
+}
+
+setTimeout(emitEvent, 15000, "hello world");


### PR DESCRIPTION
This branch adds a WebSocket server, run automatically on launch, that launches a stream (default port 8080) of all valid orders that make it through `deliverTx()`. Other changes include:
- Logger class for writing logs/errors to `stdout`
- Cleanup ABCI handler functions
- Moved `state` representation to separate file for future use