### PR TITLE
ParadigmCore patch v0.5.3(.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ node ./dist/index.js
 A formal documentation site will be launched soon, alongside a developer portal with helpful resources and tutorials for building on Paradigm.
 
 ### Ethereum peg and shared-security model
-See [`./spec/ethereum-peg.md`](./spec/ethereum-peg.md).
+See [`./spec/ethereum-peg.md`](./spec/ethereum-peg-spec.md).
 
 ### Websocket API (valid order event stream)
 See [`./docs/websocket-api.md`](./docs/websocket-api.md).


### PR DESCRIPTION
# ParadigmCore pre-release `v0.5.3(.1)`
See #27 and #24 for the most recent full changelogs.
# Overview
- Fixing a broken link in the README.