### PR TITLE
ParadigmCore release-candidate v0.7.0-rc-2

### DIFF
--- a/init.js
+++ b/init.js
@@ -176,9 +176,10 @@ function fail(msg, error, missing) {
 
 // main function
 (function () {
-    process.version.slice(1).split(".").map(i => parseInt(i))[0] > 10 ?
-    null : semVer[0] === 10 && semVer[1] >= 4 ? 
-    null : fail("Node.JS >=10.4 required.");
+    semVer = process.version.slice(1).split(".").map(i => parseInt(i));
+    semVer[0] > 10 ?
+        null : semVer[0] === 10 && semVer[1] >= 4 ? 
+        null : fail("Node.JS >=10.4 required.");
 
     // exit if paradigmcore home directory environment var not set
     if (


### PR DESCRIPTION
# ParadigmCore release-candidate `v0.7.0-rc-2`

_(copied from #36)_

A full changelog will be published when the release-candidate tag is removed, and the final`v0.7.X` is merged to master. 

This version finalizes the changes necessary to support [the dynamic validator set spec](https://github.com/paradigmfoundation/paradigmcore/blob/master/spec/validator-tx-spec.md), with several modifications and improvements made to the overall `State` interface. 

Handler functions are now better isolated from the global scope (more to be done), and the base logic for supporting the new `witness.subject` type is written. It will need to be expanded before the full spec can be implemented.

Semver minor version bump due to breaking API changes during development. This version will NOT be able to reach consensus with, or participate on a network with any older version of ParadigmCore.

# Overview
- Patching buggy `init.js` script version check function(s)
- Tendermint `v0.29` is now supported, and installed by default
- Overhaul of `State` interface (and type definitions, with better comments!)
- Removal of custom `js-abci` fork, now that [the official version](https://github.com/tendermint/js-abci) has been updated
- Improvement of ABCI handler function implementations
- Minor refactoring, etc