### PR TITLE
ParadigmCore release-candidate v0.7.0-rc-3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/tendermint"]
 	path = lib/tendermint
-	url = https://github.com/hrharder/js-tendermint
+	url = git@github.com:hrharder/js-tendermint

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <h1 align="center">
   ParadigmCore
   <a href="https://github.com/ParadigmFoundation/ParadigmCore/pull/24">
-    <code>v0.7.0-rc-1</code>
+    <code>v0.7.1-rc-1</code>
   </a>
 </h1>
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ yarn install
 
 ### Build from source
 
-Build the TypeScript source files into executable JS (by default placed at `./dist`) by running the following command. The required 
+Build the TypeScript source files into executable JS (by default placed at `./dist`) by running the following command.
 ```shell
 # build with npm
 npm run build
@@ -94,7 +94,7 @@ If needed, modify [`tsconfig.json`](./tsconfig.json) to set compiler options.
 
 ### Start
 
-Start ParadigmCore by running one of the following. Do not run the startup script directly.
+Start ParadigmCore by running one of the following. ParadigmCore will intentionally exit if initiated by executing the startup script (`src/index.ts`) directly. If this behavior is desired, you can remove that check from the startup proceedure.
 
 ```shell
 # with npm

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 <h1 align="center">
   ParadigmCore
-  <a href="https://github.com/ParadigmFoundation/ParadigmCore/pull/24">
-    <code>v0.7.2-rc-1</code>
+  <a href="https://github.com/ParadigmFoundation/ParadigmCore/pull/38">
+    <code>v0.7.0-rc-3</code>
   </a>
 </h1>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <h1 align="center">
   ParadigmCore
   <a href="https://github.com/ParadigmFoundation/ParadigmCore/pull/24">
-    <code>v0.7.1-rc-1</code>
+    <code>v0.7.2-rc-1</code>
   </a>
 </h1>
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@ title: Getting Started
 
 Follow this guide to download, configure, build, and run a full or validating OrderStream node.
 
-If you want more detailed and complete instructions, follow [this tutorial](./tutorial.html) to set up a ParadigmCore instance, and join the current OrderStream test-network. 
+If you want more detailed and complete instructions, follow [this tutorial](https://docs.paradigm.market/paradigmcore/tutorial.html) to set up a ParadigmCore instance, and join the current OrderStream test-network. 
 
 ## Setup Runtime
 
@@ -33,9 +33,9 @@ ParadigmCore is configured through it's runtime environment variables, which can
 ```bash
 $ cp lib/template.env .env
 ```
-_A blank template is also included at [`./lib/raw_template.env`](./lib/raw_template.env) for more granular control and custom configuration._
+_A blank template is also included at [`./lib/raw_template.env`](https://github.com/ParadigmFoundation/ParadigmCore/blob/master/lib/raw_template.env) for more granular control and custom configuration._
 
-The [`template.env`](./lib/template.env) is nearly-complete with some sensible defaults, but you must set the following two variables before trying to configure and run ParadigmCore:
+The [`template.env`](https://github.com/ParadigmFoundation/ParadigmCore/blob/master/lib/template.env) is nearly-complete with some sensible defaults, but you must set the following two variables before trying to configure and run ParadigmCore:
 ```bash
 # set to 'full' to configure a non-validating node
 NODE_TYPE="validator"
@@ -50,8 +50,8 @@ A local Ethereum node is recommended, but for development purposes the WebSocket
 
 If you use the `STAKE_CONTRACT_ADDR` set in the template, you must use a Ropsten provider. The Paradigm Protocol is not yet deployed on the main Ethereum network.
 
-## [Join an existing network](/paradigmcore/tutorial)
-_Note: more detailed instructions for joining a network, as well as hardware requirements for validators can be found [here](/paradigmcore/tutorial.md)._
+## [Join the OrderStream Test Network](https://github.com/ParadigmFoundation/blind-star-testnet)
+_Note: more detailed instructions for joining a network, as well as hardware requirements for validators can be found [here](./tutorial.md). Other information required to join the "blind-star" test-network [can be found in its repository.](https://github.com/ParadigmFoundation/blind-star-testnet)_
 
 If you intend to join an existing network as a full or validating node, you must also specify the following variable in your `.env` file:
 ```bash
@@ -70,7 +70,7 @@ Conveniently, all dependencies, configuration, and validation can be run with a 
 $ npm i # or yarn install
 ```
 
-This will trigger a number of steps, including the execution of [`init.js`](./init.js) which downloads the correct tendermint binary, configures it's directories, generates node keys and network genesis files, and copies some required fields (including keys) to the environment file.
+This will trigger a number of steps, including the execution of [`init.js`](https://github.com/ParadigmFoundation/ParadigmCore/blob/master/init.js) which downloads the correct tendermint binary, configures it's directories, generates node keys and network genesis files, and copies some required fields (including keys) to the environment file.
 
 It also performs validation of the environment file and (tries) to provide helpful messages in the case of incomplete or incorrect configuration. You can run this script as many times as necessary – if validation fails the first time – after making changes to the `.env` file by running `npm i` again.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,7 +4,7 @@ title: Overview
 
 # ParadigmCore
 
-ParadigmCore is the reference implementation of the OrderStream (OS) network. To read more about OS network and the high-level functionality the software enables, check out the Paradigm Protocol [whitepaper.](https://paradigm.market/whitepaper) An introduction to the protocol as a whole can be found [here](/overview/intro.html). Additional documentation and tutorials will be published over the coming weeks and months.
+ParadigmCore is the reference implementation of the OrderStream (OS) network. To read more about OS network and the high-level functionality the software enables, check out the Paradigm Protocol [whitepaper.](https://paradigm.market/whitepaper) An introduction to the protocol as a whole can be found [here](/overview/). Additional documentation and tutorials will be published over the coming weeks and months.
 
 ParadigmCore is built on [Tendermint](https://tendermint.com/), which it uses for networking and BFT consensus.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -170,7 +170,7 @@ $ sudo reboot
 
 ## Install software
 
-There are several packages you must install before you can run ParadigmCore and connect it to the OrderStream network. This includes Node.JS (the required runtime for ParadigmCore) as well as some required build tools, and an optional Ethereum client. 
+There are several packages you must install before you can run ParadigmCore and connect it to the OrderStream network. This includes Node.js (the required runtime for ParadigmCore) as well as some required build tools, and an optional Ethereum client. 
 
 ### Install build tools
 Certain ParadigmCore dependencies rely on common software build tools. Conveniently, they can all be installed with the following command(s). 
@@ -189,10 +189,10 @@ $ sudo apt-get install -y nodejs
 ```
 
 ## Configure Ethereum client
-Skip this step if you plan to use Infura or another remote `web3` provider. The instructions show below are for parity, but feel free to use geth or another Ethereum client of your choosing. 
+Skip this step if you plan to use Infura or another remote `web3` provider. The instructions show below are for `parity`, but feel free to use `geth` or another Ethereum client of your choosing. 
 
 ### Download and install binary
-Grab a recent Parity Ethereum binary with their one-liner install script.
+Grab a recent Parity Ethereum binary with their convenient one-liner install script.
 
 ```shell
 $ bash <(curl https://get.parity.io -L)
@@ -224,14 +224,14 @@ WantedBy=default.target
 ```
 
 ### Create configuration file
-Now, you will create a config.toml file that will be used by the system to configure the parity process. Currently, the OrderStream network uses Ethereum's Ropsten testnet, so to sync with the current OrderStream network, your Ethereum client must sync to the Ropsten testnet.
+Now, you will create a `config.toml` file that will be used by the system to configure the parity process. Currently, the OrderStream network uses Ethereum's Ropsten testnet, so to sync with the current OrderStream network, your Ethereum client must sync to the Ropsten testnet.
 
 ```shell
 $ sudo mkdir /etc/parity
 $ sudo touch /etc/parity/config.toml
 ```
 
-Open the newly created configuration file (with sudo privileges) and paste in the following. Adjust the config if you are deploying a custom OrderStream on a different Ethereum network.
+Open the newly created configuration file (with `sudo` privileges) and paste in the following. Adjust the config if you are deploying a custom OrderStream on a different Ethereum network.
 
 ```shell
 [parity]
@@ -263,7 +263,7 @@ This section will guide you through the process of cloning and configuring Parad
 
 ### Clone ParadigmCore source
 
-In the absence of a downloadable release for ParadigmCore, you must clone the source repository via git. 
+In the absence of a downloadable release for ParadigmCore, you must clone the source repository via `git`. 
 
 First, create a new directory in your home folder - or wherever else you wish to store, build, and run ParadigmCore.
 
@@ -282,7 +282,7 @@ $ git clone git@github.com:ParadigmFoundation/ParadigmCore ~/paradigmcore
 ```
 
 ### Set environment variables
-ParadigmCore is configured via local environment variables. You can store these config variables in a .env file (recommended) placed in the root directory of ParadigmCore. A startup script will handle the installation and configuration of tendermint, but first you must set the necessary config variables.
+ParadigmCore is configured via local environment variables. You can store these config variables in a `.env` file (recommended) placed in the root directory of ParadigmCore. A startup script will handle the installation and configuration of tendermint, but first you must set the necessary config variables.
 
 #### Copy included template
 Get started by copying a mostly filled template included with the repository. You can use a blank template (also included) for more granular control and custom setups.
@@ -296,6 +296,8 @@ Unless otherwise specified, you should run all commands in your ParadigmCore roo
 
 #### Add required fields 
 There are three fields that must be added to the `.env` in for all configurations, and an additional one for nodes joining an existing network.
+
+The most up-to-date testnet information can be found [here.](https://github.com/ParadigmFoundation/blind-star-testnet)
 
 - `NODE_TYPE` is used to configure full vs. validator (required)
 - `NODE_ENV` is for development/production (required)
@@ -312,7 +314,7 @@ If you want to run a full node, and connect it to the existing OrderStream test-
 NODE_TYPE="full"
 NODE_ENV="production"
 WEB3_PROVIDER="ws://localhost:8546"
-SEEDS="1AB8749957B75602794A0EF8306FE4E27BE5B27A@bs1.paradigm.market:26656"
+SEEDS="AB96D9C6ACA18EE587A5DC24783CFBA20636D0E8@bs1.paradigm.market:26656"
 ```
 
 If you want to run a full node on the existing test-network, but don't have or want a full Ethereum client locally, replace `WEB3_PROVIDER` with the following.
@@ -341,14 +343,14 @@ Use this configuration if you already are included as a validator in the testnet
 NODE_TYPE="validator"
 NODE_ENV="production"
 WEB3_PROVIDER="ws://localhost:8546"
-SEEDS="1AB8749957B75602794A0EF8306FE4E27BE5B27A@bs1.paradigm.market:26656"
+SEEDS="AB96D9C6ACA18EE587A5DC24783CFBA20636D0E8@bs1.paradigm.market:26656"
 ```
 
 A local Ethereum client is required for OrderStream validators. See previous lesson for parity install instructions. 
 
 ### Add genesis file
 
-Validators and full nodes intending to join the active OrderStream test-network will also need to obtain the [current `genesis.json`](https://gist.github.com/hrharder/890a9c12773bfdfb4275b1f768db9292) that the OrderStream testnet was initialized with. You will need to place that file at `lib/tendermint/config/genesis.json` and delete the file generated after the next step.
+Validators and full nodes intending to join the active OrderStream test-network will also need to obtain the [current `genesis.json`](https://github.com/ParadigmFoundation/blind-star-testnet) that the OrderStream testnet was initialized with. You will need to place that file at `lib/tendermint/config/genesis.json` and delete the file generated after the next step.
 
 ## Install dependencies
 After adding the required fields to your configuration file, you can run npm i to perform various configuration steps. It will handle the following primary steps, among other setup and validation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paradigmcore",
-  "version": "0.7.0-rc-1",
+  "version": "0.7.1-rc-1",
   "description": "TypeScript implementation of the OrderStream Network.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paradigmcore",
-  "version": "0.7.1-rc-1",
+  "version": "0.7.2-rc-1",
   "description": "TypeScript implementation of the OrderStream Network.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paradigmcore",
-  "version": "0.7.2-rc-1",
+  "version": "0.7.0-rc-3",
   "description": "TypeScript implementation of the OrderStream Network.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/api/post/HttpServer.ts
+++ b/src/api/post/HttpServer.ts
@@ -68,17 +68,21 @@ export async function start(options) {
             }
         });
 
-        // Setup express server
+        // setup express server
         app.enable("trust proxy");
         app.use(limiter);
         app.use(helmet());
         app.use(cors());
         app.use(bodyParser.json());
+
+        // attach handlers
         app.post("/*", wrapAsync(postHandler));
         app.use(errorHandler);
 
-        // Start API server
+        // start API server
         await app.listen(options.port);
+        log("api", `http api server started on port ${options.port}`);
+        
         return;
     } catch (error) {
         throw new Error(error.message);

--- a/src/api/stream/WsServer.ts
+++ b/src/api/stream/WsServer.ts
@@ -35,7 +35,7 @@ function bind(server: Server): Server {
     return server.on("connection", (connection) => {
         // Send connection message
         try {
-            Message.sendMessage(connection, msg.websocket.messages.connected);
+            Message.sendMessage(connection, "connected to order-stream");
         } catch (error) {
             err("api", `(ws) ${msg.websocket.errors.connect}`);
         }
@@ -74,7 +74,7 @@ export function start(port: number, emitter: EventEmitter) {
     try {
         // Create WebSocket server
         let server = new Server({ port }, () => {
-            log("api", msg.websocket.messages.servStart);
+            log("api", `order-stream server started on port ${port}`);
         });
 
         // Load global order emitter

--- a/src/async/Witness.ts
+++ b/src/async/Witness.ts
@@ -88,6 +88,8 @@ export class Witness {
         let total: bigint = BigInt(0);      // Total amount currently staked
         const output: Limits = {};          // Generated output mapping
 
+        try {
+
         // Calculate total balance currently staked
         Object.keys(bals).forEach((k, v) => {
             if (bals.hasOwnProperty(k) && typeof(bals[k]) === "bigint") {
@@ -102,7 +104,7 @@ export class Witness {
                 const balNum = parseInt(bals[k].toString());
                 const totNum = parseInt(total.toString());
                 const lim = (balNum / totNum) * limit;
-                
+
                 // Create limit object for each address
                 output[k] = {
                     // orderLimit is proportional to stake size
@@ -113,6 +115,11 @@ export class Witness {
                 };
             }
         });
+
+        } catch (error) {
+            err("state", "bigint issue happening here");
+            process.exit(1)
+        }
 
         // Return constructed output mapping.
         return output;

--- a/src/async/Witness.ts
+++ b/src/async/Witness.ts
@@ -694,8 +694,6 @@ export class Witness {
         // send transaction via broadcaster instance
         this.broadcaster.send(tx).catch((error) => {
             err("peg", `failed to send local abci tx: ${error.message}`);
-            console.log("bye");
-            process.exit(0);
         });
 
         // Will return OK unless ABCI is disconnected

--- a/src/async/Witness.ts
+++ b/src/async/Witness.ts
@@ -31,6 +31,7 @@ import { default as codes } from "../util/Codes";
 import { err, log } from "../util/log";
 import { messages as msg } from "../util/static/messages";
 import { createWitnessEventObject } from "../core/util/utils";
+import { bigIntReplacer } from "../util/static/bigIntUtils";
 
 /**
  * A Witness supports a one way peg-zone between Ethereum and the OrderStream to
@@ -98,8 +99,10 @@ export class Witness {
         Object.keys(bals).forEach((k, v) => {
             if (bals.hasOwnProperty(k) && typeof(bals[k]) === "bigint") {
                 // Compute proportional order limit
-                const lim = (bals[k] / total) * BigInt(limit);
-
+                const balNum = parseInt(bals[k].toString());
+                const totNum = parseInt(total.toString());
+                const lim = (balNum / totNum) * limit;
+                
                 // Create limit object for each address
                 output[k] = {
                     // orderLimit is proportional to stake size

--- a/src/async/Witness.ts
+++ b/src/async/Witness.ts
@@ -88,8 +88,6 @@ export class Witness {
         let total: bigint = BigInt(0);      // Total amount currently staked
         const output: Limits = {};          // Generated output mapping
 
-        try {
-
         // Calculate total balance currently staked
         Object.keys(bals).forEach((k, v) => {
             if (bals.hasOwnProperty(k) && typeof(bals[k]) === "bigint") {
@@ -115,11 +113,6 @@ export class Witness {
                 };
             }
         });
-
-        } catch (error) {
-            err("state", "bigint issue happening here");
-            process.exit(1)
-        }
 
         // Return constructed output mapping.
         return output;

--- a/src/core/beginBlock.ts
+++ b/src/core/beginBlock.ts
@@ -29,7 +29,7 @@ import { doForEachValidator } from "./util/valFunctions";
 export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
     return (request) => {
         // parse height and proposer from header
-        const currHeight: bigint = BigInt(request.header.height);
+        const currHeight: number = Number(request.header.height);
         const proposer: string = request.header.proposerAddress.toString("hex");
 
         // store array of last votes
@@ -40,14 +40,14 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
             lastVotes.forEach((vote: any) => {
                 // pull/parse nodeId and current vote power
                 const nodeId = vote.validator.address.toString("hex");
-                const power = BigInt(vote.validator.power);
+                const power = Number(vote.validator.power);
 
                 // TODO: sould we check for new validators here?
 
                 // update vote and height trackers
                 if (vote.signedLastBlock) {
-                    state.validators[nodeId].totalVotes += 1n;
-                    state.validators[nodeId].lastVoted = (currHeight - 1n);
+                    state.validators[nodeId].totalVotes += 1;
+                    state.validators[nodeId].lastVoted = (currHeight - 1);
                 }
 
                 // record if validator was active last round
@@ -76,7 +76,7 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
                 const validator = state.validators[key];
 
                 // mark active if vote recorded on last block
-                if (validator.lastVoted + 1n === currHeight) {
+                if ((validator.lastVoted + 1) === currHeight) {
                     validator.active = true;
                 } else {
                     validator.active = false;

--- a/src/core/beginBlock.ts
+++ b/src/core/beginBlock.ts
@@ -30,7 +30,7 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
     return (request) => {
         // parse height and proposer from header
         const currHeight: bigint = BigInt(request.header.height);
-        const currProposer: string = request.header.proposerAddress.toString("hex");
+        const proposer: string = request.header.proposerAddress.toString("hex");
 
         // store array of last votes
         const lastVotes: object[] | undefined = request.lastCommitInfo.votes;
@@ -67,7 +67,7 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
                 state.validators[nodeId].active = vote.signedLastBlock;
 
                 // record if they are proposer this round
-                if (nodeId === currProposer) {
+                if (nodeId === proposer) {
                     state.validators[nodeId].lastProposed = currHeight;
                 }
 
@@ -106,7 +106,8 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
         // Indicate new round, return no indexing tags
         log(
             "state",
-            `block #${currHeight} being proposed by validator ...${currProposer.slice(-5)}`
+            `current proposer: ${proposer.slice(0,5)} .. ${proposer.slice(-5)}`,
+            currHeight
         );
         return {};
     };

--- a/src/core/beginBlock.ts
+++ b/src/core/beginBlock.ts
@@ -42,20 +42,7 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
                 const nodeId = vote.validator.address.toString("hex");
                 const power = BigInt(vote.validator.power);
 
-                // create entry if validator has not voted yet
-                /* @todo where should this be moved?
-                if (!(state.validators.hasOwnProperty(nodeId))) {
-                    state.validators[nodeId] = {
-                        balance: BigInt(0), // @TODO re-examine
-                        power,
-                        publicKey: Buffer.from(0),
-                        ethAccount: "not-implemented",
-                        lastVoted: null,
-                        lastProposed: null,
-                        totalVotes: BigInt(0),
-                        genesis: false,
-                    };
-                }*/
+                // TODO: sould we check for new validators here?
 
                 // update vote and height trackers
                 if (vote.signedLastBlock) {
@@ -106,7 +93,7 @@ export function beginBlockWrapper(state: State): (r) => ResponseBeginBlock {
         // Indicate new round, return no indexing tags
         log(
             "state",
-            `current proposer: ${proposer.slice(0,5)} .. ${proposer.slice(-5)}`,
+            `current proposer: ${proposer.slice(0,5)}...${proposer.slice(-5)}`,
             currHeight
         );
         return {};

--- a/src/core/checkTx.ts
+++ b/src/core/checkTx.ts
@@ -15,10 +15,11 @@
 // custom typings
 import { ResponseCheckTx } from "../typings/abci";
 
-// util functions
+// utils
 import { Vote } from "./util/Vote";
 import { warn } from "../util/log";
 import { decodeTx, preVerifyTx } from "./util/utils";
+import { messages as msg } from "../util/static/messages"
 
 // tx handlers
 import { checkOrder } from "./handlers/order";
@@ -29,12 +30,18 @@ import { checkRebalance } from "./handlers/rebalance";
 /**
  * Perform light verification on incoming transactions, accept valid
  * transactions to the mempool, and reject invalid ones.
+ * 
+ * Currently, all transaction types are checked before mempool/gossip by:
+ * - encoding according to spec/implementation of TxGenerator and TxBroadcaster
+ * - zlib compression
+ * - signature from an active validator
+ * - transaction type specific rules
  *
  * @param request {object} raw transaction as delivered by Tendermint core.
  */
 export function checkTxWrapper(
     state: State,
-    msg: LogTemplates,
+    // msg: LogTemplates,
     Order: any
 ): (r) => ResponseCheckTx {
     return (request) => {

--- a/src/core/commit.ts
+++ b/src/core/commit.ts
@@ -88,7 +88,10 @@ export function commitWrapper(
 
             log(
                 "state",
-                `committing new state with hash: ...${stateHash.toString("hex").slice(-8)}`
+                `new state hash: ` + 
+                `${stateHash.toString("hex").slice(0,5)}...` +
+                `${stateHash.toString("hex").slice(-5)}`,
+                commitState.lastBlockHeight
             );
         } catch (error) {
             err("state", `${msg.abci.errors.broadcast}: ${error.message}`);

--- a/src/core/commit.ts
+++ b/src/core/commit.ts
@@ -59,10 +59,11 @@ export function commitWrapper(
                     const newEnd = deliverState.round.endsAt;
 
                     // Synchronize staking period parameters
+                    // todo: this can't be a functino call from within SM
                     witness.synchronize(newRound, newStart, newEnd);
 
                     // Temporary
-                    console.log(`\n... current state: ${JSON.stringify(commitState, bigIntReplacer)}\n`);
+                    console.log(`\n... current state: ${JSON.stringify(deliverState, bigIntReplacer)}\n`);
                     break;
                 }
 
@@ -81,6 +82,7 @@ export function commitWrapper(
             deliverState.lastBlockAppHash = stateHash;
 
             // Trigger broadcast of orders and streams
+            // todo: this can't be a function call from SM
             tracker.triggerBroadcast();
 
             // Synchronize commit state from delivertx state

--- a/src/core/commit.ts
+++ b/src/core/commit.ts
@@ -75,7 +75,7 @@ export function commitWrapper(
             }
 
             // Increase last block height
-            deliverState.lastBlockHeight += 1n;
+            deliverState.lastBlockHeight += 1;
 
             // Generate new state hash and update
             stateHash = Hasher.hashState(deliverState);

--- a/src/core/endBlock.ts
+++ b/src/core/endBlock.ts
@@ -60,6 +60,7 @@ export function endBlockWrapper(state: State): (r) => ResponseEndBlock {
         });
 
         // return validator updates, if any
-        return { validatorUpdates: [] };
+        return { validatorUpdates: [
+        ] };
     };
 }

--- a/src/core/handlers/order.ts
+++ b/src/core/handlers/order.ts
@@ -98,7 +98,7 @@ export function deliverOrder(tx: SignedOrderTx, state: State, q: OrderTracker, O
 
         // Begin state modification
         state.posters[poster].orderLimit -= 1;
-        state.orderCounter += 1n;
+        state.orderCounter += 1;
         // End state modification
 
         // Add order to block's broadcast queue

--- a/src/core/handlers/rebalance.ts
+++ b/src/core/handlers/rebalance.ts
@@ -7,7 +7,7 @@
  *
  * @author Henry Harder
  * @date (initial)  23-October-2018
- * @date (modified) 21-January-2019
+ * @date (modified) 22-January-2019
  *
  * Handler functions for verifying ABCI Rebalance transactions, originating
  * from validator nodes. Implements state transition logic as specified in the

--- a/src/core/handlers/rebalance.ts
+++ b/src/core/handlers/rebalance.ts
@@ -35,32 +35,26 @@ export function checkRebalance(tx: SignedRebalanceTx, state: State) {
     // Load proposal from rebalance tx
     const proposal: RebalanceData = tx.data;
 
-    // Check if this is the initial rebalance period
-    switch (state.round.number) {
-        // No previous periods
-        case 0: {
-            if (proposal.round.number === 1) {
-                // Accept valid initial rebalance proposal to mempool
-                log("mem", msg.rebalancer.messages.iAccept);
-                return Vote.valid();
-            } else {
-                // Reject invalid initial rebalance proposal from mempool
-                warn("mem", msg.rebalancer.messages.iReject);
-                return Vote.invalid();
-            }
+    // check if this is the initial rebalance period
+    if (state.round.number === 0) {
+        if (proposal.round.number === 1) {
+            // Accept valid initial rebalance proposal to mempool
+            log("mem", msg.rebalancer.messages.iAccept);
+            return Vote.valid();
+        } else {
+            // Reject invalid initial rebalance proposal from mempool
+            warn("mem", msg.rebalancer.messages.iReject);
+            return Vote.invalid();
         }
-
-        // Not the first period (period > 0)
-        default: {
-            if ((1 + state.round.number) === proposal.round.number) {
-                // Accept valid rebalance proposal to mempool
-                log("mem", msg.rebalancer.messages.accept);
-                return Vote.valid(msg.rebalancer.messages.accept);
-            } else {
-                // Reject invalid rebalance proposal from mempool
-                warn("mem", msg.rebalancer.messages.reject);
-                return Vote.invalid(msg.rebalancer.messages.reject);
-            }
+    } else {
+        if ((1 + state.round.number) === proposal.round.number) {
+            // Accept valid rebalance proposal to mempool
+            log("mem", msg.rebalancer.messages.accept);
+            return Vote.valid(msg.rebalancer.messages.accept);
+        } else {
+            // Reject invalid rebalance proposal from mempool
+            warn("mem", msg.rebalancer.messages.reject);
+            return Vote.invalid(msg.rebalancer.messages.reject);
         }
     }
 }
@@ -126,10 +120,10 @@ export function deliverRebalance(
                     state.round.startsAt = proposal.round.startsAt;
                     state.round.endsAt = proposal.round.endsAt;
 
-                    // TODO: move to function
+                    // copy limits from proposal to each balance
                     Object.keys(propLimits).forEach((i) => {
                         state.posters[i].orderLimit = propLimits[i].orderLimit;
-                        state.posters[i].streamLimit = propLimits[i].orderLimit;
+                        state.posters[i].streamLimit = propLimits[i].streamLimit;
                     });
                     // End state modification
 

--- a/src/core/handlers/witness.ts
+++ b/src/core/handlers/witness.ts
@@ -7,7 +7,7 @@
  *
  * @author Henry Harder
  * @date (initial)  23-October-2018
- * @date (modified) 22-January-2019
+ * @date (modified) 23-January-2019
  *
  * Handler functions for verifying ABCI event Witness transactions,
  * originating from validator nodes. Implements state transition logic as
@@ -83,7 +83,7 @@ export function deliverWitness(tx: SignedWitnessTx, state: State): Vote {
     }
 
     // unpack/parse event data after id is confirmed
-    const { subject, type, amount, block, address, publicKey, id } = parsedTx;
+    const { block, id } = parsedTx;
     
     // will be true if transaction is ultimately valid
     let accepted: boolean;
@@ -113,71 +113,4 @@ export function deliverWitness(tx: SignedWitnessTx, state: State): Vote {
         warn("state", "no reported status on witness transaction");
         return Vote.invalid();
     }
-
-    // end new logic
-
-    /*old logic bwlo
-    switch (state.events.hasOwnProperty(block)) {
-        case true: {
-            // events from this block already pending, see if new must be added
-            if (state.events[block].hasOwnProperty(id) && id === eventId) {
-                state.events[block][id].conf += 1;
-                updateMappings(state, id, address, block, amount, type);
-                log("state", "vote recorded for valid stake event (existing)");
-                return Vote.valid();
-
-            // block in state, event is not    
-            } else if (!(state.events[block].hasOwnProperty(id))) {
-                state.events[block][id] = {
-                    subject,
-                    type,
-                    address,
-                    amount,
-                    publicKey,
-                    conf: 1
-                };
-
-                // if running with single node, update balances
-                if (process.env.NODE_ENV === "development") {
-                    updateMappings(state, id, address, block, amount, type);
-                }
-
-                // voted added for valid new event
-                log("state", "voted added for valid stake event (new)");
-                return Vote.valid();
-            } else {
-                // Block and event are in state, but does not match Tx
-                warn("state", "witness tx does not match in-state event");
-                return Vote.invalid();
-            }
-        }
-
-        case false: {
-            // block is not in state yet, add new one
-            state.events[block] = {};
-
-            // add event to block
-            state.events[block][id] = {
-                subject,
-                type,
-                address,
-                amount,
-                publicKey,
-                conf: 1
-            };
-
-            // if running with single node, update balances
-            if (process.env.NODE_ENV === "development") {
-                updateMappings(state, id, address, block, amount, type);
-            }
-
-            log("state", "voted added for valid stake event (new)");
-            return Vote.valid();
-        }
-
-        // shouldn't happen, safety
-        default: {
-            return Vote.invalid();
-        }
-    }*/
 }

--- a/src/core/handlers/witness.ts
+++ b/src/core/handlers/witness.ts
@@ -15,7 +15,7 @@
  */
 
  // ParadigmCore classes
-import { log, warn } from "../../util/log";
+import { log, warn, err } from "../../util/log";
 import { Vote } from "../util/Vote";
 
 // ParadigmCore utilities/types
@@ -83,10 +83,16 @@ export function deliverWitness(tx: SignedWitnessTx, state: State): Vote {
     }
 
     // unpack/parse event data after id is confirmed
-    const { block, id } = parsedTx;
+    const { block, id, type } = parsedTx;
     
     // will be true if transaction is ultimately valid
     let accepted: boolean;
+
+    // immediatley invalidate if event is older than most recent update
+    if (state.lastEvent[type] >= block) {
+        err("state", "ignoring existing event that may have been applied");
+        return Vote.invalid();
+    }
 
     if (state.events.hasOwnProperty(block)) {
         // block is already in state

--- a/src/core/handlers/witness.ts
+++ b/src/core/handlers/witness.ts
@@ -90,7 +90,7 @@ export function deliverWitness(tx: SignedWitnessTx, state: State): Vote {
 
     // immediatley invalidate if event is older than most recent update
     if (state.lastEvent[type] >= block) {
-        err("state", "ignoring existing event that may have been applied");
+        warn("state", "ignoring existing event that may have been applied");
         return Vote.invalid();
     }
 

--- a/src/core/initChain.ts
+++ b/src/core/initChain.ts
@@ -45,7 +45,7 @@ export function initChainWrapper(
             // Generate hexadecimal nodeID from public key
             const pubKey: Buffer = validator.pubKey.data;
             const nodeId: string = pubToAddr(pubKey).toString("hex");
-            const power: bigint = BigInt(validator.power);
+            const power: number = Number(validator.power);
 
             // Create entry if validator has not voted yet
             if (!(deliverState.validators.hasOwnProperty(nodeId))) {
@@ -55,8 +55,8 @@ export function initChainWrapper(
                     publicKey: pubKey,
                     ethAccount: null,
                     lastProposed: null,
-                    lastVoted: null,
-                    totalVotes: BigInt(0),
+                    lastVoted: 0,
+                    totalVotes: 0,
                     active: true,
                     genesis: true,
                     applied: true,

--- a/src/core/util/utils.ts
+++ b/src/core/util/utils.ts
@@ -315,10 +315,10 @@ export function addConfMaybeApplyEvent(
 
     // @todo does validator and poster subjects need to be tracked separately?
     // todo: remove? move up the stack?
-    if (state.lastEvent[type] >= block) {
-        err("state", "ignoring existing event that may have been applied");
-        return false;
-    }
+    // if (state.lastEvent[type] >= block) {
+    //    err("state", "ignoring existing event that may have been applied");
+    //    return false;
+    //}
 
     // add a confirmation to the pending event
     state.events[block][id].conf += 1;
@@ -409,13 +409,10 @@ export function applyPosterEvent(state: State, tx: ParsedWitnessData): boolean {
 
     // remove the pending event that was just appled
     delete state.events[block][id];
-    console.log("\n\ndeleted that event-id dawg\n\n");
 
-    console.log("\n\nblock length: " + Object.keys(state.events[block]).length + "\n\n");
     // remove event block if none left pending
     if (Object.keys(state.events[block]).length === 0) {
         delete state.events[block];
-        console.log("\n\ndeleted that event-block dawg\n\n");
     }
 
     // when removing, also check if balance is now 0

--- a/src/core/util/utils.ts
+++ b/src/core/util/utils.ts
@@ -381,7 +381,7 @@ export function createWitnessEventHash(tx: WitnessData): string {
     
     // buffer input and create hash
     const hashBuffer = Buffer.from(hashVals);
-    const hash = createHash("sha256").update(hashBuffer).digest("hex");
+    const hash = createHash("sha256").update(hashBuffer).digest("hex").slice(16);
 
     // return hash as ID for witness event tx's
     return hash;

--- a/src/core/util/utils.ts
+++ b/src/core/util/utils.ts
@@ -255,7 +255,7 @@ export function addNewEvent(state: State, tx: ParsedWitnessData): boolean {
 
     // new events should have block > lastEvent
     if (state.lastEvent[type] >= block) {
-        err("state", "ignoring new event that may have been applied");
+        warn("state", "ignoring new event that may have been applied");
         return false;
     }
 

--- a/src/core/util/utils.ts
+++ b/src/core/util/utils.ts
@@ -381,7 +381,7 @@ export function createWitnessEventHash(tx: WitnessData): string {
     
     // buffer input and create hash
     const hashBuffer = Buffer.from(hashVals);
-    const hash = createHash("sha256").update(hashBuffer).digest("hex").slice(16);
+    const hash = createHash("sha256").update(hashBuffer).digest("hex").slice(0, 16);
 
     // return hash as ID for witness event tx's
     return hash;

--- a/src/core/util/utils.ts
+++ b/src/core/util/utils.ts
@@ -400,7 +400,6 @@ export function applyPosterEvent(state: State, tx: ParsedWitnessData): boolean {
     } else {
         // unexpected case, for now will exit process
         err("state", "unexpected: no poster account, but requesting withdrawl");
-        process.exit(1);
         accepted = false;
     }
 

--- a/src/core/util/utils.ts
+++ b/src/core/util/utils.ts
@@ -350,7 +350,7 @@ export function addConfMaybeApplyEvent(
     }
 
     // update latest event, if update was applied
-    if (accepted) state.lastEvent[type] = block;
+    // if (accepted) state.lastEvent[type] = block;
     return accepted;
 }
 
@@ -409,16 +409,22 @@ export function applyPosterEvent(state: State, tx: ParsedWitnessData): boolean {
 
     // remove the pending event that was just appled
     delete state.events[block][id];
+    console.log("\n\ndeleted that event-id dawg\n\n");
 
+    console.log("\n\nblock length: " + Object.keys(state.events[block]).length + "\n\n");
     // remove event block if none left pending
     if (Object.keys(state.events[block]).length === 0) {
         delete state.events[block];
+        console.log("\n\ndeleted that event-block dawg\n\n");
     }
 
     // when removing, also check if balance is now 0
     if (type === "remove" && state.posters[address].balance === 0n) {
         delete state.posters[address];
     }
+
+    // update latest event, if update was applied
+    if (accepted) state.lastEvent[type] = block;
 
     // if reached, accepted should be true
     return accepted;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ let node;                       // tendermint node child process instance
         process.exit(1);
     }
 
-    // order tracker and stream server
+    // order tracker and order-stream server
     logStart("starting order tracker and websocket server...");
     try {
         // Create a "parent" EventEmitter
@@ -170,7 +170,6 @@ let node;                       // tendermint node child process instance
         };
 
         await startAPIserver(options);
-        log("api", msg.api.messages.servStart);
     } catch (error) {
         err("api", "failed initializing api server.");
         err("start", error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,11 @@ let node;                       // tendermint node child process instance
             };
         }
 
+        // create tendermint subprocess
         node = tendermint.node(env.TM_HOME, options);
+
+        // if in debug mode, pipe tendermint logs to STDOUT
+        if (env.DEBUG) node.stdout.pipe(process.stdout);
     } catch (error) {
         err("state", "failed starting tendermint.");
         err("state", "tendermint may not be installed or configured.");

--- a/src/state/commitState.ts
+++ b/src/state/commitState.ts
@@ -33,7 +33,7 @@ export let commitState: State = {
     maxOrderBytes: null,
     confirmationThreshold: null
   },
-  orderCounter: 0n,
-  lastBlockHeight: 0n,
+  orderCounter: 0,
+  lastBlockHeight: 0,
   lastBlockAppHash: null
 };

--- a/src/state/deliverState.ts
+++ b/src/state/deliverState.ts
@@ -33,7 +33,7 @@ export let deliverState: State = {
     maxOrderBytes: null,
     confirmationThreshold: null
   },
-  orderCounter: 0n,
-  lastBlockHeight: 0n,
+  orderCounter: 0,
+  lastBlockHeight: 0,
   lastBlockAppHash: null
 };

--- a/src/typings/state.d.ts
+++ b/src/typings/state.d.ts
@@ -54,12 +54,12 @@ interface State {
      * Incremental counter of the number of 'order' and 'stream' transactions 
      * accpeted on the network since genesis.
      */
-    orderCounter:       bigint;
+    orderCounter:       number;
 
     /**
      * Tendermint specific, tracks last commited height.
      */
-    lastBlockHeight:    bigint;
+    lastBlockHeight:    number;
 
     /**
      * Tendermint specific, tracks last commited app hash.
@@ -124,12 +124,12 @@ interface ValidatorInfo {
  */
 interface Validator {
     balance:        bigint; // balance in registry contract
-    power:          bigint; // vote power on tendermint chain
+    power:          number; // vote power on tendermint chain
     publicKey:      Buffer; // raw 32 byte public key 
     ethAccount:     string;
-    lastVoted:      bigint;
-    lastProposed:   bigint;
-    totalVotes:     bigint;
+    lastVoted:      number;
+    lastProposed:   number;
+    totalVotes:     number;
     active?:        boolean; // true if voted on last block
     genesis?:       boolean; // true if val was in genesis.json
     applied:        boolean; // true if a) in genesis or b) through endblock

--- a/src/typings/transaction.d.ts
+++ b/src/typings/transaction.d.ts
@@ -156,7 +156,7 @@ interface WitnessData extends TransactionData {
     amount:     string; // stringified bigint
     block:      number; // block number of event
     address:    string; // ethereum address of validator/poster
-    publicKey:  string | undefined; // tendermint ed25519 key of validator
+    publicKey:  string; // tendermint ed25519 key of validator (base64 enc string)
     id?:        string; // hash of event data
 }
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -17,14 +17,12 @@ function print(msg, lvl) {
 }
 
 export function logStart(msg?) {
-    // return if invalid function call
     if (!msg) {
         // special welcome message
         print(
-            `${c.gray("lvl:")} ${c.bold("info")}\t` +
-            `welcome :)` +
-            `${c.bold("\tstarting paradigm core")}` +
-            ` v${c.italic(version)}`,
+            `${c.gray("lvl:")} ${c.bold("info")}\twelcome :)\t` +
+            `starting ${c.bold.greenBright("paradigm core")}` +
+            ` v${version}`,
             -1
         );
     } else {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -11,6 +11,7 @@ function ts(): string {
 }
 
 function print(msg, lvl) {
+    if (lvl === -1) {  console.log(`\n${ts()} ${msg}\n`); return; }
     if (level > lvl || _.isUndefined(levels[lvl])) { return; }
     console.log(`${ts()} ${msg}`);
 }
@@ -18,26 +19,45 @@ function print(msg, lvl) {
 export function logStart(msg?) {
     // return if invalid function call
     if (!msg) {
+        // special welcome message
         print(
-            `${c.bold.green("startup")}\t${c.bold("info")}\t` +
-            `starting ${c.bold.blue("paradigm-core")} v${version}...`,
-            2
+            `${c.gray("lvl:")} ${c.bold("info")}\t` +
+            `welcome :)` +
+            `${c.bold("\tstarting paradigm core")}` +
+            ` v${c.italic(version)}`,
+            -1
         );
     } else {
         print(
-            `${c.bold.green("startup")}\t${c.bold("info")}\t${msg}`,
+            `${c.gray("lvl:")} ${c.bold("info")}\t` +
+            `${c.gray("mod:")} ${c.bold.green("startup")}\t` +
+            `${c.gray("msg:")} ${msg}`,
             2
         );
     }
 }
 
-export function log(mod: string, msg: string) {
+export function log(mod: string, msg: string, height?: number | bigint) {
     // return if invalid function call
     if (_.isUndefined(defs[mod]) || !_.isString(msg)) { return; }
 
+    // special case for state machine ("core") module and TM blockchain
+    if (mod === "state" && height) {
+        print(
+            `${c.gray("lvl:")} ${c.bold("info")}\t` + 
+            `${c.gray("mod:")} ${c.bold[(defs[mod].color)](defs[mod].label)}\t` + 
+            `${c.gray("msg:")} ${msg}\t` +
+            `${c.gray("height: ")} ${height}`,
+            0
+        );
+        return;
+    }
+
     // write to stdout with log level 0 (info/all)
     print(
-        `${c.bold[(defs[mod].color)](defs[mod].label)}\t${c.bold("info")}\t${msg}`,
+        `${c.gray("lvl:")} ${c.bold("info")}\t` + 
+        `${c.gray("mod:")} ${c.bold[(defs[mod].color)](defs[mod].label)}\t` + 
+        `${c.gray("msg:")} ${msg}`,
         0
     );
 }
@@ -47,8 +67,10 @@ export function warn(mod: string, msg: string) {
     if (_.isUndefined(defs[mod]) || !_.isString(msg)) { return; }
 
     // write to stdout with log level 1 (warnings)
-    print(
-        `${c.bold[(defs[mod].color)](defs[mod].label)}\t${c.bold.yellow("warn")}\t${msg}`,
+     print(
+        `${c.gray("lvl:")} ${c.bold.yellow("warn")}\t` + 
+        `${c.gray("mod:")} ${c.bold[(defs[mod].color)](defs[mod].label)}\t` + 
+        `${c.gray("msg:")} ${msg}`,
         1
     );
 }
@@ -59,7 +81,9 @@ export function err(mod: string, msg: string) {
 
     // write to stdout with log level 2 (errors)
     print(
-        `${c.bold[(defs[mod].color)](defs[mod].label)}\t${c.bold.red("error")}\t${msg}`,
+        `${c.gray("lvl:")} ${c.bold.red("error")}\t` + 
+        `${c.gray("mod:")} ${c.bold[(defs[mod].color)](defs[mod].label)}\t` + 
+        `${c.gray("msg:")} ${msg}`,
         2
     );
 }

--- a/src/util/static/messages.ts
+++ b/src/util/static/messages.ts
@@ -33,8 +33,8 @@ export let messages  = {
             fatal:      "fatal error starting websocket server, exiting"
         },
         messages: {
-            connected:  `Connected to the OrderStream network at ${new Date().toLocaleString()}`,
-            servStart:  `websocket server started on port ${WS_PORT}`,
+            // connected:  `Connected to the OrderStream network at ${new Date().toLocaleString()}`,
+            // servStart:  `websocket server started on port ${WS_PORT}`,
         }
     },
     abci: {
@@ -55,7 +55,7 @@ export let messages  = {
             mempool:    "new order passed mempool verification",
             noStake:    "new order rejected: invalid poster or no poster stake",
             verified:   "new order verified and added to OrderStream queue",
-            servStart:  `abci server started on port ${ABCI_PORT}`,
+            // servStart:  `abci server started on port ${ABCI_PORT}`,
             roundDiff:  "this round deliverTx state is more than 1 period ahead of committed state",
             badSig:     "rejected ABCI transaction with invalid validator signature"
         }
@@ -68,8 +68,8 @@ export let messages  = {
             fatal:      "fatal error starting API server, exiting"
         },
         messages: {
-            starting:   "starting http api server...",
-            servStart:  `api server started on port ${API_PORT}`
+            // starting:   "starting http api server...",
+            // servStart:  `api server started on port ${API_PORT}`
         }
     },
     rebalancer: {


### PR DESCRIPTION
# ParadigmCore release-candidate `v0.7.0-rc-3`

_(copied from #37)_

A full changelog will be published when the release-candidate tag is removed, and the final`v0.7` is merged to master. 

This version finalizes the changes necessary to support [the dynamic validator set spec](https://github.com/paradigmfoundation/paradigmcore/blob/master/spec/validator-tx-spec.md), with several modifications and improvements made to the overall `State` interface. 

Handler functions are now better isolated from the global scope (more to be done), and the base logic for supporting the new `witness.subject` type is written. It will need to be expanded before the full spec can be implemented.

Semver minor version bump due to breaking API changes during development. This version will NOT be able to reach consensus with, or participate on a network with any older version of ParadigmCore.

# Overview
- Fixing ABCI server connection issues
- Updating documentation for latest test-network
- Patching buggy `init.js` script version check function(s)
- Tendermint `v0.29` is now supported, and installed by default
- Overhaul of `State` interface (and type definitions, with better comments!)
- Removal of custom `js-abci` fork, now that [the official version](https://github.com/tendermint/js-abci) has been updated
- Improvement of ABCI handler function implementations
- Minor refactoring, new/better comments, etc.